### PR TITLE
Support for publish with GitHub pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        cache: npm
+
+    - name: Install dependencies
+      run: npm ci
+    - name: Build website
+      run: npm run build
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,12 @@ jobs:
 
     - name: Install dependencies
       run: npm ci
+
     - name: Build website
+      env:
+        # Optional base url set in repo secrets e.g. /rchain-docs/
+        # Workaround for https://github.com/facebook/docusaurus/issues/448
+        BASE_URL: ${{ secrets.BASE_URL }}
       run: npm run build
 
     - name: Deploy to GitHub Pages

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,0 +1,22 @@
+name: Test deployment
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test-deploy:
+    name: Test deployment
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        cache: npm
+
+    - name: Install dependencies
+      run: npm ci
+    - name: Test build website
+      run: npm run build

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -18,5 +18,6 @@ jobs:
 
     - name: Install dependencies
       run: npm ci
+
     - name: Test build website
       run: npm run build

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,7 +9,7 @@ const config = {
   title: 'RChain docs',
   tagline: 'RChain general documentations : dev | validation | staking',
   url: 'https://docs.rchain.coop',
-  baseUrl: '/',
+  baseUrl: process.env.BASE_URL ?? '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.png',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,14 @@
 import React from 'react';
-import  { Redirect } from 'react-router-dom';
+import { Redirect } from 'react-router-dom';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
-export default function Home() {
-  return <Redirect to='/docs/development/dev_on_rchain' />;
+export default function Home () {
+  const context = useDocusaurusContext();
+
+  // Retrieve reference to home page redirect
+  const homeDoc = context.siteConfig.themeConfig.navbar.items[0]
+  const homeDocUrl = useBaseUrl(`docs/${homeDoc.docId}`)
+
+  return <Redirect to={homeDocUrl} />;
 }


### PR DESCRIPTION
## GitHub workflow for publish with GitHub pages

Added GitHub action files to build and publish the site when `master` branch is updated. Also added action for test build when PR is created or modified.

## Fix for baseUrl configuration

It also fixes a problem with `baseUrl` which doesn't support relative path.
https://github.com/facebook/docusaurus/issues/448

Default for basUrl is `/`. This is OK for sites published directly on the root of the domain without application path.
If the site if not on the root repo secret `BASE_URL` can be specified with custom application path e.g. `/rchain-docs/` (both slashes are important).
![image](https://user-images.githubusercontent.com/5306205/183051095-466ea3b1-a54a-4fc2-bda0-6f1d6a1d0df0.png)
