### PR TITLE
Make checking for env.BASE_URL more resilient on empty values

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,7 +9,7 @@ const config = {
   title: 'RChain docs',
   tagline: 'RChain general documentations : dev | validation | staking',
   url: 'https://docs.rchain.coop',
-  baseUrl: process.env.BASE_URL ?? '/',
+  baseUrl: (process.env.BASE_URL ?? '').trim() || '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.png',


### PR DESCRIPTION
## Overview

Improve check for environment BASE_URL to include empty string even with spaces.